### PR TITLE
Remove `search' filter expressions

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -18,7 +18,7 @@
 - name: Create random temporary directory for ldif file
   command: mktemp -d
   register: slapd_register_tempdir
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
   check_mode: no
 
 - name: Prepare temporary ldif file
@@ -28,17 +28,17 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Restart slapd (first time only)
   service:
     name: 'slapd'
     state: 'restarted'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Configure TLS certificates (first time only)
   shell: 'ldapmodify -Y EXTERNAL -H ldapi:/// -f {{ slapd_register_tempdir.stdout|d() + "/configure_tlscerts.ldif" }}'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Configure TLS certificates
   ldap_attrs:

--- a/templates/lookup/slapd_ldap_access_control_list.j2
+++ b/templates/lookup/slapd_ldap_access_control_list.j2
@@ -1,5 +1,5 @@
 {% set disable_counter = False %}
-{% if slapd_ldap_access_control_list|d([]) and slapd_ldap_access_control_list[0] | search("^{") %}
+{% if slapd_ldap_access_control_list|d([]) and slapd_ldap_access_control_list[0] is search("^{") %}
 {% set disable_counter = True %}
 {% endif %}
 {% for item in slapd_ldap_access_control_list %}

--- a/templates/lookup/slapd_ldap_limits.j2
+++ b/templates/lookup/slapd_ldap_limits.j2
@@ -1,5 +1,5 @@
 {% set disable_counter = False %}
-{% if slapd_ldap_limits|d([]) and slapd_ldap_limits[0] | search("^{") %}
+{% if slapd_ldap_limits|d([]) and slapd_ldap_limits[0] is search("^{") %}
 {% set disable_counter = True %}
 {% endif %}
 {% for item in slapd_ldap_limits %}


### PR DESCRIPTION
Search as a filter was removed with ansible 2.9.2.